### PR TITLE
Add support for non-packaged locally-installed scrapers.

### DIFF
--- a/src/scraper-index.ts
+++ b/src/scraper-index.ts
@@ -1,10 +1,11 @@
 // import types from scraper index
 import { scraperExport } from "../types/scraperIndex.js"
+import { localScraper } from "../types/stashapp.js"
 import axios from "axios"
 import { StashApp } from "./stash-app.js"
 
 // scraper index searcher and installer
-async function searchScrapers(url: string): Promise<string[]> {
+async function searchCommunityScrapers(url: string): Promise<string[]> {
   // fetch communityScrapers
   const communityScrapers = await axios.get("https://stashapp.github.io/CommunityScrapers/assets/scrapers.json")
     .then(res => res.data as scraperExport[])
@@ -16,19 +17,39 @@ async function searchScrapers(url: string): Promise<string[]> {
   return matchedScrapers.map(scraper => scraper.filename.replace('../scrapers/', '').replace('.yml', '').split("/")[0])
 }
 
+// Checks scrapers locally installed on the Stash instance for one which handles `url`. Returns the IDs of any matching scrapers.
+async function searchLocalScrapers(url: string, stash: StashApp): Promise<string[]> {
+  const localScrapers = await stash.getLocalScrapers()
+  const matchedScrapers = localScrapers.filter((scraper: localScraper) =>
+    scraper.sites && scraper.sites.some(pattern => url.includes(pattern))
+  )
+  return matchedScrapers.map(scraper => scraper.id)
+}
+
 // handle url scrapersearch
 export async function scraperSearch(url: string, stash: StashApp): Promise< { error: string } | { success: string, id: string } > {
-  // search in CommunityScrapers
-  const matchedScrapers = await searchScrapers(url)
-  // if no results, return empty array
-  if (matchedScrapers.length === 0) return { "error": "No scrapers found for the provided URL." }
-  // check for existing scrapers
-  const existingScrapers = await stash.getExistingScrapers()
-  // check against IDs
-  const hasExistingScrapers = matchedScrapers.filter(scraper => existingScrapers.includes(scraper))
-  // if no existing and only one matched, install it
-  if (hasExistingScrapers.length === 0 && matchedScrapers.length === 1) {
-    const scraperId = matchedScrapers[0]
+  // check whether there is already a scraper installed for this URL
+  const matchedLocalScrapers = await searchLocalScrapers(url, stash)
+  // if one existing, return success
+  if (matchedLocalScrapers.length == 1) {
+    return {
+      success: `Scraper ${matchedLocalScrapers[0]} already installed.`,
+      id: matchedLocalScrapers[0]
+    }
+  } else if (matchedLocalScrapers.length > 1) {
+    return {
+      success: "Multiple scrapers already installed",
+      id: matchedLocalScrapers[1]
+    }
+  }
+
+  // else, search CommunityScrapers
+  const matchedCommunityScrapers = await searchCommunityScrapers(url)
+  // if still no results, return empty array
+  if (matchedCommunityScrapers.length === 0) return { "error": "No scrapers found for the provided URL." }
+  // if only one matched, install it
+  if (matchedCommunityScrapers.length === 1) {
+    const scraperId = matchedCommunityScrapers[0]
     console.log(`Installing scraper: ${scraperId}`)
     return stash.installPackage(scraperId)
       .then((jobId: number) => stash.awaitJobFinished(jobId))
@@ -36,19 +57,8 @@ export async function scraperSearch(url: string, stash: StashApp): Promise< { er
         success: `Scraper ${scraperId} installed successfully.`,
         id: scraperId
       }))
-  } else if (matchedScrapers.length > 1 && hasExistingScrapers.length === 0) {
+  } else {
     // if multiple, don't install
     return { "error": "Multiple scrapers found for the provided URL. Cowardly refusing to install." }
-  } else if (hasExistingScrapers.length == 1) {
-    // if one existing, return success
-    return {
-      success: `Scraper ${hasExistingScrapers[0]} already installed.`,
-      id: hasExistingScrapers[0]
-    }
-  } else {
-    return {
-      success: "Multiple scrapers already installed",
-      id: hasExistingScrapers[1]
-    }
   }
 }

--- a/src/stash-app.ts
+++ b/src/stash-app.ts
@@ -1,6 +1,6 @@
 import { getLastScraperUpdate, setLastScraperUpdate } from "./db.js"
 import { scraperSearch } from "./scraper-index.js"
-import { installedPackage, logEntry } from "../types/stashapp.js"
+import { installedPackage, localScraper, logEntry } from "../types/stashapp.js"
 import axios from "axios"
 import { sceneResult, cleanSceneResult, stashInfo, partialJobResult } from "../types/jobResult.js"
 import crypto from "crypto"
@@ -86,9 +86,12 @@ export class StashApp {
     this.callGQL('mutation { updatePackages(type: Scraper) }')
       .then(data => data.updatePackages)
 
-  getExistingScrapers = async (): Promise<string[]> => this.callGQL(`query {
-      installedPackages(type: Scraper) { package_id }
-    }`).then(data => data.installedPackages.map((pkg: installedPackage) => pkg.package_id))
+  // Only checks scene scrapers for now.
+  getLocalScrapers = async (): Promise<localScraper[]> => this.callGQL(`query {
+      listScrapers(types: [SCENE]) { id, scene {urls} }
+    }`).then(data => data.listScrapers.map((scraper: {id: string, scene: {urls: string[]}}): localScraper => {
+      return {id: scraper.id, sites: scraper.scene.urls}
+    }))
 
   installPackage = (id: String): Promise<number> => this.callGQL(`mutation ($id: String!) {
     installPackages(

--- a/types/stashapp.ts
+++ b/types/stashapp.ts
@@ -4,6 +4,11 @@ export type installedPackage = {
   date: string
 }
 
+export type localScraper = {
+  id: string,
+  sites: string[]
+}
+
 export type logEntry = {
   time: string,
   level: "Trace" | "Debug" | "Info" | "Warning" | "Error",


### PR DESCRIPTION
Rather than always checking the CommunityScrapers list for a matching scraper, it will now first check what's installed (regardless of where it's installed from), falling back to looking for a community scraper to install.

I was working on adding a new site to an existing scraper, so when I was testing the update, scraperSearch would return early because the new site's URL is not in the CommunityScrapers list (yet).