### PR TITLE
Pass repo owner name when running action to build docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,3 +23,5 @@ jobs:
       - uses: docker/bake-action@v6
         with:
           push: true
+          variables: |
+            OWNER_NAME=${{ github.repository_owner }}


### PR DESCRIPTION
Otherwise the action will fail for anyone who isn't `feederbox826`.

(There was another instance of this PR sent and then I botched it, so here is a new one.)