### PR TITLE
Scene cover image UI changes

### DIFF
--- a/public/assets/custom.css
+++ b/public/assets/custom.css
@@ -1,8 +1,17 @@
 #result-image-placeholder {
+  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
   height: 100%;
   width: 100%;
   font-size: 2rem;
+}
+
+#result-image-placeholder:hover {
+  background-color: var(--bs-dark);
+}
+
+.Image {
+  justify-content: center;
 }


### PR DESCRIPTION
* Center scene cover image. It currently goes to the left when not 16:9. Sample of existing behavior: [relatively SFW scene scrape](https://scrape-ci.feederbox.cc/scene?id=zJYq9bG8APN41)

* When hovering on the "Click to show image" placeholder, change background color and cursor icon. Hopefully this makes it more obvious to click when you do want it, and avoid clicking when you don't.